### PR TITLE
Use io.open in setup.py to specify UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import io
 
 from metaphone import meta
 
@@ -12,7 +13,7 @@ setup(
     url=meta.url,
     license=meta.license,
     packages=find_packages(),
-    long_description=open("README.rst").read(),
+    long_description=io.open("README.rst", encoding='utf-8').read(),
     tests_require = ['nose'],
     test_suite = 'nose.collector',
     )


### PR DESCRIPTION
The built-in 'open' call was causing issues due to encoding during installation of the package on a ubuntu-based docker image with Python 3.5.  Replaced the 'open' call with 'io.open' and specified UTF-8 encoding to address this installation problem.